### PR TITLE
Don't store LS data in versioned directory

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,7 @@
         "func-call-spacing": "error",
         "func-name-matching": "error",
         "func-names": "off",
-        "func-style": "error",
+        "func-style": "off",
         "function-paren-newline": "error",
         "generator-star-spacing": "error",
         "getter-return": "error",

--- a/src/db/lokijs/database.js
+++ b/src/db/lokijs/database.js
@@ -37,7 +37,7 @@ module.exports = {
   start(dirPath = null, saveInterval = defaultSaveInterval) {
     return new Promise((res, rej)=>{
       try {
-        const dbPath = path.join(dirPath || commonConfig.getModulePath(config.moduleName), `${config.moduleName}.db`);
+        const dbPath = path.join(dirPath || commonConfig.getModuleDir(), config.moduleName, `${config.moduleName}.db`);
 
         db = new loki(dbPath, {
           autoload: true,

--- a/src/files/file-system.js
+++ b/src/files/file-system.js
@@ -21,12 +21,12 @@ module.exports = {
     return crypto.createHash("md5").update(filePath).digest("hex");
   },
   getCacheDir() {
-    const modulePath = commonConfig.getModulePath(config.moduleName);
-    return path.join(modulePath, DIR_CACHE);
+    const modulePath = commonConfig.getModuleDir();
+    return path.join(modulePath, config.moduleName, DIR_CACHE);
   },
   getDownloadDir() {
-    const modulePath = commonConfig.getModulePath(config.moduleName);
-    return path.join(modulePath, DIR_DOWNLOAD);
+    const modulePath = commonConfig.getModuleDir();
+    return path.join(modulePath, config.moduleName, DIR_CACHE);
   },
   getDiskThreshold() {
     return halfGB;

--- a/src/files/file-system.js
+++ b/src/files/file-system.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   getDownloadDir() {
     const modulePath = commonConfig.getModuleDir();
-    return path.join(modulePath, config.moduleName, DIR_CACHE);
+    return path.join(modulePath, config.moduleName, DIR_DOWNLOAD);
   },
   getDiskThreshold() {
     return halfGB;

--- a/test/integration/db/lokijs/database.js
+++ b/test/integration/db/lokijs/database.js
@@ -18,10 +18,10 @@ describe("lokijs - integration", ()=>{
   });
 
   it("creates local-storage.db file", (done)=>{
-    const tempDBPath = path.join(os.tmpdir(), "lokijs_test_dir");
+    const tempDBPath = path.join(os.tmpdir(), "local-storage");
     platform.mkdirRecursively(tempDBPath)
     .then(()=>{
-      return database.start(tempDBPath, dbSaveInterval);
+      return database.start(os.tmpdir(), dbSaveInterval);
     })
     .then(()=>{
       return setTimeout(()=>{

--- a/test/unit/files/file-system.js
+++ b/test/unit/files/file-system.js
@@ -9,11 +9,12 @@ const platform = require("rise-common-electron").platform;
 
 describe("File System", ()=> {
 
-  const testModulePath = "rvplayer/modules/local-storage/";
+  const mockModulePath = "rvplayer/modules/";
+  const expectedDataPath = "rvplayer/modules/local-storage/";
   const testFilePath = "test-bucket/test-folder/test-file.jpg";
 
   beforeEach(() => {
-    simple.mock(commonConfig, "getModulePath").returnWith(testModulePath);
+    simple.mock(commonConfig, "getModuleDir").returnWith(mockModulePath);
   });
 
   afterEach(() => {
@@ -22,19 +23,19 @@ describe("File System", ()=> {
 
   describe("getCacheDir", () => {
     it("should provide path to cache folder", ()=> {
-      assert.equal(fileSystem.getCacheDir(), `${testModulePath}cache`);
+      assert.equal(fileSystem.getCacheDir(), `${expectedDataPath}cache`);
     });
   });
 
   describe("getDownloadDir", () => {
     it("should provide path to download folder", ()=> {
-      assert.equal(fileSystem.getDownloadDir(), `${testModulePath}download`);
+      assert.equal(fileSystem.getDownloadDir(), `${expectedDataPath}download`);
     });
   });
 
   describe("getPathInCache", () => {
     it("should provide path for a file in cache given a gcs filePath", ()=> {
-      assert.equal(fileSystem.getPathInCache(testFilePath), `${testModulePath}cache/e498da09daba1d6bb3c6e5c0f0966784`);
+      assert.equal(fileSystem.getPathInCache(testFilePath), `${expectedDataPath}cache/e498da09daba1d6bb3c6e5c0f0966784`);
     });
   });
 
@@ -50,7 +51,7 @@ describe("File System", ()=> {
 
   describe("getPathInDownload", () => {
     it("should return the path to a file in download folder given a gcs filePath", () => {
-      assert.equal(fileSystem.getPathInDownload(testFilePath), `${testModulePath}download/e498da09daba1d6bb3c6e5c0f0966784`);
+      assert.equal(fileSystem.getPathInDownload(testFilePath), `${expectedDataPath}download/e498da09daba1d6bb3c6e5c0f0966784`);
     });
   });
 
@@ -114,16 +115,16 @@ describe("File System", ()=> {
 
     it("should move the file", () => {
       mockfs({
-        [`${testModulePath}download`]: {
+        [`${expectedDataPath}download`]: {
           "e498da09daba1d6bb3c6e5c0f0966784": "some content"
         },
-        [`${testModulePath}cache`]: {}
+        [`${expectedDataPath}cache`]: {}
       });
 
       return fileSystem.moveFileFromDownloadToCache(testFilePath)
         .then(()=>{
-          assert(!platform.fileExists(`${testModulePath}download/e498da09daba1d6bb3c6e5c0f0966784`));
-          assert(platform.fileExists(`${testModulePath}cache/e498da09daba1d6bb3c6e5c0f0966784`));
+          assert(!platform.fileExists(`${expectedDataPath}download/e498da09daba1d6bb3c6e5c0f0966784`));
+          assert(platform.fileExists(`${expectedDataPath}cache/e498da09daba1d6bb3c6e5c0f0966784`));
 
         })
         .catch((err) => {
@@ -137,7 +138,7 @@ describe("File System", ()=> {
 
     it("should delete a file in download directory", (done) => {
       mockfs({
-        [`${testModulePath}download`]: {
+        [`${expectedDataPath}download`]: {
           "e498da09daba1d6bb3c6e5c0f0966784": "some content"
         }
       });
@@ -145,7 +146,7 @@ describe("File System", ()=> {
       fileSystem.deleteFileFromDownload(testFilePath);
 
       setTimeout(()=>{
-        assert(!platform.fileExists(`${testModulePath}download/e498da09daba1d6bb3c6e5c0f0966784`));
+        assert(!platform.fileExists(`${expectedDataPath}download/e498da09daba1d6bb3c6e5c0f0966784`));
         done();
       }, 200);
     });
@@ -156,16 +157,16 @@ describe("File System", ()=> {
 
     it("should delete all files in download directory", () => {
       mockfs({
-        [`${testModulePath}download`]: {
+        [`${expectedDataPath}download`]: {
           "e498da09daba1d6bb3c6e5c0f0966784": "some content"
         }
       });
 
-      assert(platform.fileExists(`${testModulePath}download/e498da09daba1d6bb3c6e5c0f0966784`));
+      assert(platform.fileExists(`${expectedDataPath}download/e498da09daba1d6bb3c6e5c0f0966784`));
 
       return fileSystem.cleanupDownloadFolder(testFilePath)
         .then(() => {
-          assert(!platform.fileExists(`${testModulePath}download/e498da09daba1d6bb3c6e5c0f0966784`));
+          assert(!platform.fileExists(`${expectedDataPath}download/e498da09daba1d6bb3c6e5c0f0966784`));
         });
     });
 

--- a/test/unit/files/file.js
+++ b/test/unit/files/file.js
@@ -14,6 +14,7 @@ const fileSystem = require("../../../src/files/file-system");
 describe("File", ()=>{
 
   const testFilePath = "test-bucket/test-folder/test-file.jpg";
+  const mockModuleDir = "rvplayer/modules";
   const testModulePath = "rvplayer/modules/local-storage/";
   const testSignedURL = "http://test-signed-url";
   const mockSuccessfulResponse = {statusCode: 200, headers: {"Content-length": "100000"}};
@@ -71,7 +72,7 @@ describe("File", ()=>{
   describe("writeToDisk", ()=> {
     beforeEach(()=>{
       simple.mock(commonConfig, "broadcastMessage").returnWith();
-      simple.mock(commonConfig, "getModulePath").returnWith(testModulePath);
+      simple.mock(commonConfig, "getModuleDir").returnWith(mockModuleDir);
 
       // Mock the file system.
       mockfs({
@@ -137,8 +138,6 @@ describe("File", ()=>{
           console.log("shouldn't be here", err);
           assert(false);
         });
-
-
     });
 
     it("should delete file from download folder and broadcast FILE-ERROR when I/O error", () => {

--- a/test/unit/messaging/watch/watch.js
+++ b/test/unit/messaging/watch/watch.js
@@ -11,6 +11,7 @@ const fileController = require("../../../../src/files/file-controller");
 
 describe("Messaging", ()=>{
 
+  const mockModuleDir = "rvplayer/modules";
   const testModulePath = "rvplayer/modules/local-storage/";
   const testFilePath = "test-bucket/test-folder/test-file.jpg";
   const testToken = {
@@ -35,7 +36,7 @@ describe("Messaging", ()=>{
 
     beforeEach(()=>{
       simple.mock(commonConfig, "sendToMessagingService").returnWith();
-      simple.mock(commonConfig, "getModulePath").returnWith(testModulePath);
+      simple.mock(commonConfig, "getModuleDir").returnWith(mockModuleDir);
       simple.mock(commonConfig, "broadcastMessage").returnWith();
       simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
 
@@ -167,7 +168,7 @@ describe("Messaging", ()=>{
       simple.mock(commonConfig, "broadcastMessage").returnWith();
       simple.mock(commonConfig, "broadcastMessage").returnWith();
       simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
-      simple.mock(commonConfig, "getModulePath").returnWith(testModulePath);
+      simple.mock(commonConfig, "getModuleDir").returnWith(mockModuleDir);
 
       simple.mock(db.fileMetadata, "put").resolveWith();
       simple.mock(db.watchlist, "put").resolveWith();


### PR DESCRIPTION
We don't want cache, db, or download data to be abandoned on every
version update of Local Storage.