### PR TITLE
Feature/Implement direct caching from passed data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,12 +26,7 @@
             "never"
         ],
         "callback-return": "error",
-        "camelcase": [
-            "error",
-            {
-                "properties": "never"
-            }
-        ],
+        "camelcase": "off",
         "capitalized-comments": "off",
         "class-methods-use-this": "error",
         "comma-dangle": "error",

--- a/src/db/api.js
+++ b/src/db/api.js
@@ -170,6 +170,62 @@ module.exports = {
         res();
       });
     }
-  }
+  },
+  directCacheFileMetadata: {
+    clear: ()=>database.getCollection("directcachemetadata").clear(),
+    allEntries: ()=>database.getCollection("directcachemetadata").find(),
+    setAll(updateObj) {
+      database.getCollection("directcachemetadata")
+      .findAndUpdate({}, (doc)=>Object.assign(doc, updateObj));
+    },
+    get(fileId, field = "") {
+      if (!fileId) {throw Error("missing params");}
 
+      const metadata = database.getCollection("directcachemetadata");
+      const item = metadata.by("fileId", fileId);
+
+      return field ? item && item[field] : item;
+    },
+    put(entry) {
+      if (!entry) {throw Error("missing params");}
+
+      return new Promise((res, rej)=>{
+        const metadata = database.getCollection("directcachemetadata");
+
+        let item = metadata.by("fileId", entry.fileId);
+
+        if (!item) {
+          item = metadata.insert({fileId: entry.fileId});
+        }
+
+        Object.assign(item, entry);
+
+        try {
+          metadata.update(item);
+        } catch (err) {
+          rej(err);
+        }
+
+        res(entry);
+      });
+    },
+    delete(fileId) {
+      if (!fileId) {throw Error("missing params");}
+
+      return new Promise((res, rej)=>{
+        const metadata = database.getCollection("directcachemetadata");
+        const item = metadata.by("componentId", fileId);
+
+        if (item) {
+          try {
+            metadata.remove(item);
+          } catch (err) {
+            rej(err);
+          }
+        }
+
+        res();
+      });
+    }
+  }
 };

--- a/src/db/lokijs/database.js
+++ b/src/db/lokijs/database.js
@@ -1,6 +1,7 @@
-const COLLECTION_METADATA = "metadata",
-  COLLECTION_OWNERS = "owners",
-  COLLECTION_WATCH_LIST = "watchlist";
+const COLLECTION_METADATA = "metadata";
+const COLLECTION_OWNERS = "owners";
+const COLLECTION_WATCH_LIST = "watchlist";
+const COLLECTION_DIRECT_CACHE_METADATA = "directcachemetadata";
 
 const commonConfig = require("common-display-module");
 const config = require("../../../src/config/config");
@@ -18,6 +19,16 @@ const initCollections = () => {
     if (!collection) {
       db.addCollection(collName, {
         unique: ["filePath"]
+      });
+    }
+  });
+
+  [COLLECTION_DIRECT_CACHE_METADATA].forEach((collName)=>{
+    const collection = db.getCollection(collName);
+
+    if (!collection) {
+      db.addCollection(collName, {
+        unique: ["fileId"]
       });
     }
   });

--- a/src/files/file.js
+++ b/src/files/file.js
@@ -95,5 +95,42 @@ module.exports = {
         rej(new Error("File I/O Error"));
       }
     });
+  },
+  writeDirectlyToDisk(fileId, data, from) {
+    if (!fileId || !data) {throw Error("Invalid write to disk params")}
+
+    log.file(`Writing data directly to ${fileId} from ${from}`);
+
+    // console.log(filePath);
+    const pathInCache = fileSystem.getPathInCache(fileId);
+
+    // console.log(pathInCache);
+    return new Promise((res, rej) => {
+      const file = fs.createWriteStream(pathInCache)
+      file.write(data);
+
+      file.on("finish", () => {
+        file.close();
+        res();
+      })
+      file.on("error", (err) => {
+        handleError(err);
+      });
+
+      file.end();
+
+
+      function handleError(err) {
+        log.file(err && err.stack ? err.stack : err)
+
+        broadcastIPC.broadcast("FILE-ERROR", {
+          fileId,
+          msg: "File I/O Error",
+          detail: err ? err.message || util.inspect(err, {depth: 1}) : ""
+        });
+
+        rej(new Error("File I/O Error"));
+      }
+    });
   }
 };

--- a/src/messaging/broadcast-ipc.js
+++ b/src/messaging/broadcast-ipc.js
@@ -13,8 +13,11 @@ module.exports = {
     ));
   },
   fileUpdate(data = {}) {
-    log.file(`Broadcasting ${data.status} FILE-UPDATE for ${data.filePath}`);
-    const ospath = {ospath: fileSystem.getPathInCache(data.filePath)};
+    let fileKey = data.filePath;
+    if (data.status === "CACHED") {fileKey = data.fileId}
+
+    log.file(`Broadcasting ${data.status} FILE-UPDATE for ${fileKey}`);
+    const ospath = {ospath: fileSystem.getPathInCache(fileKey)};
     module.exports.broadcast("FILE-UPDATE", Object.assign({}, data, ospath));
   },
   fileError(data = {}) {

--- a/src/messaging/delete/delete.js
+++ b/src/messaging/delete/delete.js
@@ -19,5 +19,20 @@ module.exports = {
           status: "DELETED"
         });
       });
+  },
+  directCacheProcess(message) {
+    const {fileId} = message;
+
+    if (!fileId) {
+      return Promise.reject(new Error("Invalid delete message"));
+    }
+
+    return db.directCacheFileMetadata.delete(fileId)
+      .then(()=>{
+        broadcastIPC.broadcast("FILE-UPDATE", {
+          fileId,
+          status: "DELETED"
+        });
+      });
   }
 };

--- a/src/messaging/get/entry.js
+++ b/src/messaging/get/entry.js
@@ -1,0 +1,7 @@
+module.exports = {
+  validateDirectCacheProcess({fileId} = {}) {
+    if (!fileId) {return false;}
+
+    return true;
+  }
+};

--- a/src/messaging/get/get.js
+++ b/src/messaging/get/get.js
@@ -1,0 +1,18 @@
+const broadcastIPC = require("../broadcast-ipc.js");
+const db = require("../../db/api");
+const entry = require("./entry");
+
+module.exports = {
+  directCacheProcess(message) {
+    const {fileId} = message;
+
+    if (!entry.validateDirectCacheProcess({fileId})) {
+      return Promise.reject(new Error("Invalid CACHE message"));
+    }
+
+    const retrievedMetadata = db.directCacheFileMetadata.get(fileId)
+
+    if (!retrievedMetadata || !retrievedMetadata.fileId) {throw Error("invalid retrieved file");}
+    broadcastIPC.fileUpdate(Object.assign({}, {fileId}, {status: "CACHED"}));
+  }
+};

--- a/src/messaging/messaging.js
+++ b/src/messaging/messaging.js
@@ -3,6 +3,7 @@ const config = require("../../src/config/config");
 const deleteFile = require("./delete/delete");
 const update = require("./update/update");
 const watch = require("./watch/watch");
+const get = require("./get/get");
 const util = require("util");
 const fileSystem = require("../../src/files/file-system");
 
@@ -48,16 +49,45 @@ const handleMSFileUpdate = (message) => {
   }
 };
 
+const handleDirectCacheFileUpdate = (message) => {
+  if (!message.type) {return;}
+
+  switch (message.type.toUpperCase()) {
+    case "UPDATE":
+      return update.directCacheProcess(message)
+        .catch((err) => {
+          logError(err, "Handle DIRECTCACHEFILEUPDATE - UPDATE Error", message.filePath);
+        });
+    case "GET":
+      try {
+        get.directCacheProcess(message);
+      } catch (err) {
+        logError(err, "Handle DIRECTCACHEFILEUPDATE - GET Error", message.filePath);
+      }
+      break;
+    case "DELETE":
+      return deleteFile.directCacheProcess(message)
+        .catch((err) => {
+          logError(err, "Handle DIRECTCACHEFILEUPDATE - DELETE Error", message.filePath);
+        });
+    default:
+  }
+};
+
 const messageReceiveHandler = (message) => {
   if (!message) {return;}
   if (!message.topic) {return;}
 
-  if (message.topic.toUpperCase() === "WATCH") {
-    return handleWatch(message);
-  } else if (message.topic.toUpperCase() === "WATCH-RESULT") {
-    return handleWatchResult(message);
-  } else if (message.topic.toUpperCase() === "MSFILEUPDATE") {
-    return handleMSFileUpdate(message);
+  switch (message.topic.toUpperCase()) {
+      case "WATCH":
+        return handleWatch(message);
+      case "WATCH-RESULT":
+        return handleWatchResult(message);
+      case "MSFILEUPDATE":
+        return handleMSFileUpdate(message);
+      case "DIRECTCACHEFILEUPDATE":
+        return handleDirectCacheFileUpdate(message);
+      default:
   }
 };
 

--- a/src/messaging/update/entry.js
+++ b/src/messaging/update/entry.js
@@ -6,6 +6,10 @@ module.exports = {
     if (!token.hash || !token.data) {return false;}
 
     return gcsValidator.validateFilepath(filePath);
+  },
+  validateDirectCacheProcess({fileId, data, from} = {}) {
+    if (!fileId || !data || typeof data !== 'string' || !from) {return false;}
+
+    return true;
   }
 };
-

--- a/src/messaging/update/update.js
+++ b/src/messaging/update/update.js
@@ -1,5 +1,6 @@
 const db = require("../../db/api");
 const entry = require("./entry");
+const file = require("../../files/file");
 
 module.exports = {
   process(message) {
@@ -16,5 +17,20 @@ module.exports = {
 
       return action(dbEntry);
     }));
+  },
+  directCacheProcess(message) {
+    const {fileId, data, from, timestamp} = message;
+
+    log.file(`Received updated version ${timestamp} for ${fileId}`);
+
+    if (!entry.validateDirectCacheProcess({fileId, data, from})) {
+      return Promise.reject(new Error("Invalid add/update message"));
+    }
+
+    // check size before calling
+    return file.writeDirectlyToDisk(fileId, data, from)
+    .then(() => {
+      db.directCacheFileMetadata.put(Object.assign({}, {fileId, timestamp}));
+    });
   }
 };

--- a/src/messaging/update/update.js
+++ b/src/messaging/update/update.js
@@ -27,7 +27,6 @@ module.exports = {
       return Promise.reject(new Error("Invalid add/update message"));
     }
 
-    // check size before calling
     return file.writeDirectlyToDisk(fileId, data, from)
     .then(() => {
       db.directCacheFileMetadata.put(Object.assign({}, {fileId, timestamp}));

--- a/test/unit/db/lokijs/database.js
+++ b/test/unit/db/lokijs/database.js
@@ -24,5 +24,6 @@ describe("lokijs", ()=>{
     assert(database.getCollection("metadata"));
     assert(database.getCollection("owners"));
     assert(database.getCollection("watchlist"));
+    assert(database.getCollection("directcachemetadata"));
   });
 });

--- a/test/unit/messaging/delete/delete.js
+++ b/test/unit/messaging/delete/delete.js
@@ -62,4 +62,50 @@ describe("Messaging", ()=>{
     });
   });
 
+  describe("DELETE - direct caching", ()=>{
+    let messageReceiveHandler = null;
+
+    const mockReceiver = {
+      on(evt, handler) {
+        if (evt === "message") {
+          messageReceiveHandler = handler;
+        }
+      }
+    };
+
+    beforeEach(()=>{
+      simple.mock(commonConfig, "broadcastMessage").returnWith();
+      simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
+      simple.mock(commonConfig, "getLocalStoragePath").returnWith("test-local-storage-path/");
+
+      simple.mock(db.directCacheFileMetadata, "delete").resolveWith();
+      simple.mock(broadcastIPC, "broadcast");
+
+      return messaging.init();
+    });
+
+    afterEach(()=>{
+      simple.restore();
+    });
+
+
+    it("deletes file in direct-cache database and broadcasts FILE-UPDATE with DELETED status", ()=>{
+      const msg = {
+        topic: "directcachefileupdate",
+        type: "delete",
+        from: "twitter",
+        fileId: "test_component_id"
+      };
+
+      return messageReceiveHandler(msg)
+        .then(()=>{
+          assert(db.directCacheFileMetadata.delete.called);
+          assert.equal(db.directCacheFileMetadata.delete.lastCall.args[0], msg.fileId);
+
+          assert(broadcastIPC.broadcast.called);
+          assert.equal(broadcastIPC.broadcast.lastCall.args[0], "FILE-UPDATE");
+          assert.deepEqual(broadcastIPC.broadcast.lastCall.args[1], {fileId: msg.fileId, status: "DELETED"});
+        });
+    });
+  });
 });

--- a/test/unit/messaging/get/entry.js
+++ b/test/unit/messaging/get/entry.js
@@ -1,0 +1,13 @@
+/* eslint-env mocha */
+const assert = require("assert");
+const entry = require("../../../../src/messaging/get/entry");
+
+describe("GET entry", ()=> {
+  describe("validate - direct caching", ()=> {
+    it("should validate correct entry value", ()=> {
+      assert.equal(entry.validateDirectCacheProcess(), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: ""}), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: "testing"}), true);
+    });
+  });
+});

--- a/test/unit/messaging/get/get.js
+++ b/test/unit/messaging/get/get.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+/* eslint-disable max-statements */
+const assert = require("assert");
+const simple = require("simple-mock");
+const commonConfig = require("common-display-module");
+const db = require("../../../../src/db/api");
+const file = require("../../../../src/files/file");
+const messaging = require("../../../../src/messaging/messaging.js");
+const broadcastIPC = require("../../../../src/messaging/broadcast-ipc.js");
+
+describe("Messaging", ()=>{
+
+  describe("GET - direct caching", ()=>{
+    let messageReceiveHandler = null;
+
+    const mockReceiver = {
+      on(evt, handler) {
+        if (evt === "message") {
+          messageReceiveHandler = handler;
+        }
+      }
+    };
+
+    beforeEach(()=>{
+      simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
+      simple.mock(commonConfig, "getLocalStoragePath").returnWith("test-local-storage-path/");
+
+      simple.mock(file, "writeDirectlyToDisk");
+      simple.mock(db.directCacheFileMetadata, "put");
+      simple.mock(broadcastIPC, "broadcast");
+
+      return messaging.init();
+    });
+
+    afterEach(()=>{
+      simple.restore();
+    });
+
+    it("broadcasts message with retrieved cached file path", ()=>{
+      const msg = {
+        topic: "directcachefileupdate",
+        type: "get",
+        from: "twitter",
+        fileId: "test_component_id"
+      };
+      const expectedMetadata = {fileId: msg.fileId, timestamp: '2018.01.01.02.02'};
+
+      simple.mock(db.directCacheFileMetadata, "get").returnWith(expectedMetadata);
+
+      messageReceiveHandler(msg);
+
+      assert(broadcastIPC.broadcast.called);
+      assert.equal(broadcastIPC.broadcast.lastCall.args[0], "FILE-UPDATE");
+    });
+  });
+});

--- a/test/unit/messaging/update/entry.js
+++ b/test/unit/messaging/update/entry.js
@@ -14,14 +14,24 @@ describe("UPDATE entry", ()=> {
     afterEach(() => {
       simple.restore();
     });
+    it("should validate correct entry value", ()=> {
+      assert.equal(entry.validate(), false);
+      assert.equal(entry.validate({filePath: "test-file"}), false);
+      assert.equal(entry.validate({filePath: "test-file", version: "test-version"}), false);
+      assert.equal(entry.validate({filePath: "test-file", version: "test-version", token: {}}), false);
+      assert.equal(entry.validate({filePath: "test-file", version: "test-version", token: {hash: "abc123", data: {timestamp: Date.now(), filePath: "test-file", displayId: "test-display"}}}), true);
+    });
   });
 
-  it("should validate correct entry value", ()=> {
-    assert.equal(entry.validate(), false);
-    assert.equal(entry.validate({filePath: "test-file"}), false);
-    assert.equal(entry.validate({filePath: "test-file", version: "test-version"}), false);
-    assert.equal(entry.validate({filePath: "test-file", version: "test-version", token: {}}), false);
-    assert.equal(entry.validate({filePath: "test-file", version: "test-version", token: {hash: "abc123", data: {timestamp: Date.now(), filePath: "test-file", displayId: "test-display"}}}), false);
+  describe("validate - direct caching", ()=> {
+    it("should validate correct entry value", ()=> {
+      assert.equal(entry.validateDirectCacheProcess(), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: "testing"}), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: "testing", data: {"test": "test"}}), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: "testing", data: {"test": "test"}, from: ""}), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: "testing", data: {"test": "test"}, from: "testing"}), false);
+      assert.equal(entry.validateDirectCacheProcess({fileId: "testing", data: JSON.stringify({"test": "test"}), from: "testing"}), true);
+    });
   });
 
 });

--- a/test/unit/messaging/update/update.js
+++ b/test/unit/messaging/update/update.js
@@ -2,6 +2,8 @@
 /* eslint-disable max-statements */
 const assert = require("assert");
 const simple = require("simple-mock");
+const path = require("path");
+const os = require("os");
 const commonConfig = require("common-display-module");
 const platform = require("rise-common-electron").platform;
 const db = require("../../../../src/db/api");
@@ -86,6 +88,8 @@ describe("Messaging", ()=>{
         }
       }
     };
+    const tmpdir = os.tmpdir();
+    const tempCacheDir = path.join(tmpdir, `local-storage-cache${Math.random()}`);
 
     beforeEach(()=>{
       simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
@@ -93,8 +97,10 @@ describe("Messaging", ()=>{
 
       simple.mock(file, "writeDirectlyToDisk");
       simple.mock(db.directCacheFileMetadata, "put");
+      simple.mock(fileSystem, "getCacheDir").returnWith(tempCacheDir);
 
-      return messaging.init();
+      return platform.mkdirRecursively(fileSystem.getCacheDir())
+      .then(messaging.init);
     });
 
     afterEach(()=>{


### PR DESCRIPTION
Please hold on review - looking into Circle CI. Will tag when ready. 

Adds functionality to directly cache passed data (and not via GCS path) given a `fileId` via LM, accepting the following messages:
```
DIRECTCACHEFILEUPDATE - UPDATE
DIRECTCACHEFILEUPDATE - GET
DIRECTCACHEFILEUPDATE - DELETE
```
We will be using this functionality for third-party modules such as Twitter and Instagram.
  
  