### PR TITLE
Add new WATCH owner on WATCH

### DIFF
--- a/test/unit/messaging/delete/delete.js
+++ b/test/unit/messaging/delete/delete.js
@@ -6,6 +6,7 @@ const db = require("../../../../src/db/api");
 const simple = require("simple-mock");
 const commonConfig = require("common-display-module");
 const broadcastIPC = require("../../../../src/messaging/broadcast-ipc.js");
+global.log = global.log || {};
 
 describe("Messaging", ()=>{
 
@@ -21,12 +22,14 @@ describe("Messaging", ()=>{
     };
 
     beforeEach(()=>{
+      simple.mock(log, "file").returnWith();
       simple.mock(commonConfig, "broadcastMessage").returnWith();
       simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
       simple.mock(commonConfig, "getLocalStoragePath").returnWith("test-local-storage-path/");
 
       simple.mock(db.fileMetadata, "delete").resolveWith();
       simple.mock(db.owners, "delete").resolveWith();
+      simple.mock(db.owners, "get").returnWith({owners: ["test"]});
       simple.mock(db.watchlist, "delete").resolveWith();
       simple.mock(broadcastIPC, "broadcast");
 

--- a/test/unit/messaging/watch/watch.js
+++ b/test/unit/messaging/watch/watch.js
@@ -37,6 +37,7 @@ describe("Messaging", ()=>{
       simple.mock(commonConfig, "sendToMessagingService").returnWith();
       simple.mock(commonConfig, "getModuleDir").returnWith(mockModuleDir);
       simple.mock(commonConfig, "broadcastMessage").returnWith();
+      simple.mock(db.owners, "get").returnWith({owners: ["test"]});
       simple.mock(commonConfig, "receiveMessages").resolveWith(mockReceiver);
       simple.mock(global.log, "file").returnWith();
 
@@ -115,6 +116,7 @@ describe("Messaging", ()=>{
       const mockMetadata = {};
 
       simple.mock(db.fileMetadata, "get").returnWith(mockMetadata);
+      simple.mock(db.owners, "addToSet").resolveWith();
 
       const msg = {
         topic: "watch",
@@ -122,8 +124,10 @@ describe("Messaging", ()=>{
         filePath: testFilePath
       };
 
-      messageReceiveHandler(msg);
-      assert(commonConfig.sendToMessagingService.called);
+      return messageReceiveHandler(msg)
+      .then(()=>{
+        assert(commonConfig.sendToMessagingService.called);
+      });
     });
 
     it("calls remote watch when the local file state is UNKNOWN", ()=>{
@@ -139,8 +143,10 @@ describe("Messaging", ()=>{
         filePath: testFilePath
       };
 
-      messageReceiveHandler(msg);
-      assert(commonConfig.sendToMessagingService.called);
+      return messageReceiveHandler(msg)
+      .then(()=>{
+        assert(commonConfig.sendToMessagingService.called);
+      });
     });
   });
 


### PR DESCRIPTION
A previous watch call should not prevent subsequent watchers from being
added to OWNERS list.

OWNERS aren't currently used to isolate FILE-UPDATE messages to modules.
They're being broadcast to all modules. But the websocket connection
owner does depend on being included in OWNERS list.