### PR TITLE
Fixing required detail object in log.all() call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1194,7 +1194,7 @@
       "dev": true
     },
     "common-display-module": {
-      "version": "git://github.com/Rise-Vision/common-display-module.git#42f217e803573ebfec6475d81ce8c736d83e726f",
+      "version": "git://github.com/Rise-Vision/common-display-module.git#b070a6d939d25740b1fd8467d4bef933b5b996e1",
       "requires": {
         "https-proxy-agent": "2.1.1",
         "node-ipc": "9.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "zip-webpack-plugin": "^2.0.0"
   },
   "dependencies": {
-    "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#v3.0.1",
+    "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#v3.0.3",
     "fs-extra": "^4.0.2",
     "gcs-filepath-validator": "^1.0.0",
     "lokijs": "^1.5.1",

--- a/src/licensing.js
+++ b/src/licensing.js
@@ -49,7 +49,7 @@ module.exports = {
 
         module.exports.sendLicensing();
 
-        return log.all(getUserFriendlyStatus(), null, null, config.bqTableName);
+        log.all("storage subscription update", {event_details: getUserFriendlyStatus(), version: config.getModuleVersion()}, null, config.bqTableName);
       }
     }
 

--- a/src/messaging/messaging.js
+++ b/src/messaging/messaging.js
@@ -79,14 +79,13 @@ const messageReceiveHandler = (message) => {
     default:
       log.debug(`Unrecognized message topic: ${message.topic}`);
   }
-
-  commonMessaging.getClientList(config.moduleName);
 };
 
 module.exports = {
   init() {
     return commonMessaging.receiveMessages(config.moduleName).then((receiver) => {
       receiver.on("message", messageReceiveHandler);
+      commonMessaging.getClientList(config.moduleName);
     });
   }
 };

--- a/test/unit/licensing.js
+++ b/test/unit/licensing.js
@@ -67,7 +67,7 @@ describe("Licensing", ()=> {
       assert(config.isAuthorized());
 
       assert(log.all.called);
-      assert.equal(log.all.lastCall.args[0], "authorized");
+      assert.equal(log.all.lastCall.args[1].event_details, "authorized");
     });
 
     it("should not be authorized if Rise Storage is not active", () => {
@@ -89,7 +89,7 @@ describe("Licensing", ()=> {
       assert(!config.isAuthorized());
 
       assert(log.all.called);
-      assert.equal(log.all.lastCall.args[0], "unauthorized");
+      assert.equal(log.all.lastCall.args[1].event_details, "unauthorized");
     });
 
     it("should not be authorized if Rise Storage is not present", () => {
@@ -130,7 +130,7 @@ describe("Licensing", ()=> {
 
         assert.equal(licensing.sendLicensing.callCount, 1);
         assert.equal(log.all.callCount, 1);
-        assert.equal(log.all.lastCall.args[0], "unauthorized");
+        assert.equal(log.all.lastCall.args[1].event_details, "unauthorized");
       }
 
       {
@@ -170,7 +170,7 @@ describe("Licensing", ()=> {
 
         assert.equal(licensing.sendLicensing.callCount, 2);
         assert.equal(log.all.callCount, 2);
-        assert.equal(log.all.lastCall.args[0], "authorized");
+        assert.equal(log.all.lastCall.args[1].event_details, "authorized");
       }
 
       {


### PR DESCRIPTION
- Aside from the fix proposed in https://github.com/Rise-Vision/common-display-module/pull/41 , the broken `log.all()` is also fixed here by including details object which it should do anyway. 
- Also fixing `getClientList()` from being called every time a message is received. 