### PR TITLE
Feature/compare hashed watchlists at startup

### DIFF
--- a/src/messaging/messaging.js
+++ b/src/messaging/messaging.js
@@ -3,6 +3,7 @@ const config = require("../../src/config/config");
 const deleteFile = require("./delete/delete");
 const update = require("./update/update");
 const watch = require("./watch/watch");
+const watchlist = require("./watch/watchlist");
 const licensing = require("../licensing");
 const util = require("util");
 
@@ -26,6 +27,13 @@ const handleWatchResult = (message) => {
   return watch.msResult(message)
   .catch((err) => {
     logError(err, "Handle WATCH-RESULT Error", message.filePath);
+  });
+};
+
+const handleWatchlistResult = (message) => {
+  return watchlist.updateFilesStatusAndRequestUpdatedFiles(message.updatedFilePaths)
+  .catch((err) => {
+    logError(err, "Handle WATCHLIST-RESULT Error", "");
   });
 };
 
@@ -76,6 +84,8 @@ const messageReceiveHandler = (message) => {
       return handleWatch(message);
     case "WATCH-RESULT":
       return handleWatchResult(message);
+    case "WATCHLIST-RESULT":
+      return handleWatchlistResult(message);
     default:
       log.debug(`Unrecognized message topic: ${message.topic}`);
   }

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -7,7 +7,7 @@ module.exports = {
   process(message) {
     const {filePath, from} = message;
 
-    log.file(`Recieved watch for ${filePath}`);
+    log.file(`Recieved watch from ${from} for ${filePath}`);
 
     if (!entry.validate({filePath, owner: from})) {
       return Promise.reject(new Error("Invalid watch message"));

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -1,4 +1,4 @@
-const broadcastIPC = require("../broadcast-ipc.js");
+const broadcastIPC = require("../broadcast-ipc");
 const commonMessaging = require("common-display-module/messaging");
 const db = require("../../db/api");
 const entry = require("./entry");

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -22,11 +22,11 @@ module.exports = {
         return requestMSUpdate(message, metaData);
       }
 
-      return Promise.resolve(broadcastIPC.fileUpdate({
+      return broadcastIPC.fileUpdate({
         filePath,
         status: metaData.status,
         version: metaData.version
-      }));
+      });
     });
   },
   msResult(message) {

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -1,8 +1,30 @@
 const commonMessaging = require("common-display-module/messaging");
 const db = require("../../db/api");
+const watch = require("./watch");
 
 function updateFilesStatusAndRequestUpdatedFiles(filePaths) {
-  return Promise.resolve(filePaths);
+  if (filePaths.length === 0) {
+    return Promise.resolve();
+  }
+
+  log.all('refreshing files', filePaths.join(', '));
+
+  return Promise.all(filePaths.map(filePath => {
+    const metaData = db.fileMetadata.get(filePath);
+    const item = db.owners.get(filePath);
+
+    // will happen when folders contain new entries, but we'll ignore those for now
+    if (!item || !metaData) {
+      return false;
+    }
+
+    // just take the first, so process() call won't fail
+    const from = item.owners[0];
+    metaData.status = "UNKNOWN";
+
+    return db.fileMetadata.put(metaData)
+    .then(() => watch.process({filePath, from}));
+  }));
 }
 
 function requestWatchlistCompare() {

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -1,6 +1,10 @@
 const commonMessaging = require("common-display-module/messaging");
 const db = require("../../db/api");
 
+function updateFilesStatusAndRequestUpdatedFiles(filePaths) {
+  return Promise.resolve(filePaths);
+}
+
 function requestWatchlistCompare() {
   const watchlist = db.watchlist.allEntries()
   .map(({filePath, version}) => ({filePath, version}));
@@ -11,5 +15,6 @@ function requestWatchlistCompare() {
 }
 
 module.exports = {
-  requestWatchlistCompare
+  requestWatchlistCompare,
+  updateFilesStatusAndRequestUpdatedFiles
 };

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "max-lines": "off",
+    "max-statements": "off"
+  }
+}

--- a/test/integration/messaging/watch/watchlist.js
+++ b/test/integration/messaging/watch/watchlist.js
@@ -1,4 +1,6 @@
 /* eslint-env mocha */
+/* eslint-disable no-magic-numbers */
+
 const assert = require("assert");
 const commonMessaging = require("common-display-module/messaging");
 const os = require("os");
@@ -6,11 +8,14 @@ const path = require("path");
 const {platform} = require("rise-common-electron");
 const simple = require("simple-mock");
 
+const broadcastIPC = require("../../../../src/messaging/broadcast-ipc");
 const database = require("../../../../src/db/lokijs/database");
 const db = require("../../../../src/db/api");
 const watchlist = require("../../../../src/messaging/watch/watchlist");
 
 const dbSaveInterval = 5;
+
+global.log = {file: ()=>{}, debug: ()=>{}, error: ()=>{}, all: () => {}};
 
 describe("watchlist - integration", ()=>{
   before(()=>{
@@ -33,11 +38,15 @@ describe("watchlist - integration", ()=>{
   });
 
   beforeEach(()=>{
+    simple.mock(broadcastIPC, "fileUpdate").returnWith();
     simple.mock(commonMessaging, "sendToMessagingService").returnWith();
   });
 
   afterEach(()=>{
     simple.restore();
+
+    db.fileMetadata.clear();
+    db.owners.clear();
     db.watchlist.clear();
   });
 
@@ -71,6 +80,63 @@ describe("watchlist - integration", ()=>{
           version: "2"
         }
       ]
+    });
+  });
+
+  it("requests status for all filepaths updated", () => {
+    db.fileMetadata.put({
+      filePath: "bucket/file1", status: "CURRENT", version: "1"
+    });
+    db.fileMetadata.put({
+      filePath: "bucket/file2", status: "CURRENT", version: "2"
+    });
+    db.fileMetadata.put({
+      filePath: "bucket/file3", status: "CURRENT", version: "3"
+    });
+
+    db.owners.addToSet({filePath: "bucket/file1", owner: "licensing"});
+    db.owners.addToSet({filePath: "bucket/file2", owner: "licensing"});
+    db.owners.addToSet({filePath: "bucket/file3", owner: "display-control"});
+
+    const updated = ["bucket/file1", "bucket/file3"];
+
+    return watchlist.updateFilesStatusAndRequestUpdatedFiles(updated)
+    .then(() => {
+      assert(!broadcastIPC.fileUpdate.called);
+      assert.equal(commonMessaging.sendToMessagingService.callCount, 2);
+
+      commonMessaging.sendToMessagingService.calls.forEach(call => {
+        const message = call.args[0];
+
+        assert(typeof message === 'object');
+
+        switch (message.filePath) {
+          case "bucket/file1": return assert.equal(message.version, "1");
+          case "bucket/file3": return assert.equal(message.version, "3");
+          default: assert.fail(message.filePath);
+        }
+      });
+
+      {
+        const metaData = db.fileMetadata.get("bucket/file1");
+        assert.equal(metaData.filePath, "bucket/file1");
+        assert.equal(metaData.status, "PENDING");
+        assert.equal(metaData.version, "1");
+      }
+
+      {
+        const metaData = db.fileMetadata.get("bucket/file2");
+        assert.equal(metaData.filePath, "bucket/file2");
+        assert.equal(metaData.status, "CURRENT");
+        assert.equal(metaData.version, "2");
+      }
+
+      {
+        const metaData = db.fileMetadata.get("bucket/file3");
+        assert.equal(metaData.filePath, "bucket/file3");
+        assert.equal(metaData.status, "PENDING");
+        assert.equal(metaData.version, "3");
+      }
     });
   });
 });

--- a/test/unit/messaging/watch/watchlist.js
+++ b/test/unit/messaging/watch/watchlist.js
@@ -1,15 +1,21 @@
 /* eslint-env mocha */
+/* eslint-disable function-paren-newline, array-bracket-newline, no-magic-numbers */
+
 const assert = require("assert");
 const simple = require("simple-mock");
 const commonMessaging = require("common-display-module/messaging");
 
 const db = require("../../../../src/db/api");
+const watch = require("../../../../src/messaging/watch/watch");
 const watchlist = require("../../../../src/messaging/watch/watchlist");
+
+global.log = {file: ()=>{}, debug: ()=>{}, error: ()=>{}, all: () => {}};
 
 describe("watchlist - unit", ()=>{
 
   beforeEach(()=>{
     simple.mock(commonMessaging, "sendToMessagingService").returnWith();
+    simple.mock(watch, "process").returnWith();
   });
 
   afterEach(() => simple.restore());
@@ -44,6 +50,46 @@ describe("watchlist - unit", ()=>{
         }
       ]
     });
+  });
+
+  it("requests update from a list of filepaths received", ()=> {
+    const testEntries = [
+      {filePath: "bucket/file1", status: "CURRENT", version: "1"},
+      {filePath: "bucket/file2", status: "CURRENT", version: "2"},
+      {filePath: "bucket/file3", status: "CURRENT", version: "3"}
+    ];
+
+    simple.mock(db.owners, "get").returnWith({owners: ['licensing']});
+    simple.mock(db.fileMetadata, "get").callFn(filePath =>
+      testEntries.find(entry => entry.filePath === filePath)
+    );
+    simple.mock(db.fileMetadata, "put").resolveWith();
+
+    const updated = ["bucket/file1", "bucket/file3"];
+
+    return watchlist.updateFilesStatusAndRequestUpdatedFiles(updated)
+    .then(() => {
+      assert(watch.process.callCount, 2);
+
+      watch.process.calls.forEach(call => {
+        const message = call.args[0];
+
+        assert(typeof message === 'object');
+        assert.equal(message.from, 'licensing');
+        assert(updated.includes(message.filePath));
+      });
+
+      assert.deepEqual(testEntries, [
+        {filePath: "bucket/file1", status: "UNKNOWN", version: "1"},
+        {filePath: "bucket/file2", status: "CURRENT", version: "2"},
+        {filePath: "bucket/file3", status: "UNKNOWN", version: "3"}
+      ]);
+    });
+  });
+
+  it("does not request update if no filepaths are received", ()=> {
+    return watchlist.updateFilesStatusAndRequestUpdatedFiles([])
+    .then(() => assert(!watch.process.called));
   });
 
 });

--- a/test/unit/messaging/watch/watchlist.js
+++ b/test/unit/messaging/watch/watchlist.js
@@ -69,7 +69,7 @@ describe("watchlist - unit", ()=>{
 
     return watchlist.updateFilesStatusAndRequestUpdatedFiles(updated)
     .then(() => {
-      assert(watch.process.callCount, 2);
+      assert.equal(watch.process.callCount, 2);
 
       watch.process.calls.forEach(call => {
         const message = call.args[0];


### PR DESCRIPTION
This PR implements the basic handler for WATCHLIST-RESULT ( still not sent by MS ).

Currently considers only files that were previously being added as being watched.
This means that this code still does not consider files for watched folders. For that I'll first wait for the outcome of https://trello.com/c/TtTQm8wX/3987-3-review-and-test-rls-and-ms-handle-watch-messages-for-entire-folders
