### PR TITLE
Feature/replace refresh all with compare watchlist

### DIFF
--- a/src/db/api.js
+++ b/src/db/api.js
@@ -191,7 +191,12 @@ module.exports = {
       return entry.lastChanged;
     },
     setLastChanged(lastChanged = 0) {
-      module.exports.watchlist.lastChanged();
+      const previous = module.exports.watchlist.lastChanged();
+
+      if (Number(previous) >= Number(lastChanged)) {
+        return;
+      }
+
       setAll("last_changed", {lastChanged});
     }
   }

--- a/src/db/api.js
+++ b/src/db/api.js
@@ -190,7 +190,7 @@ module.exports = {
 
       return entry.lastChanged;
     },
-    setLastChanged(lastChanged = 0) {
+    setLastChanged(lastChanged = "0") {
       const previous = module.exports.watchlist.lastChanged();
 
       if (Number(previous) >= Number(lastChanged)) {

--- a/src/db/api.js
+++ b/src/db/api.js
@@ -186,7 +186,7 @@ module.exports = {
       const entries = allEntries("last_changed");
 
       const entry = entries.length === 0 ?
-        database.getCollection("last_changed").insert({lastChanged: 0}) : entries[0];
+        database.getCollection("last_changed").insert({lastChanged: '0'}) : entries[0];
 
       return entry.lastChanged;
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const database = require("./db/lokijs/database");
 const fileSystem = require("./files/file-system");
 const messaging = require("./messaging/messaging");
-const refreshAllWatchEntries = require("./messaging/watch/refresh-all");
+const watchlist = require("./messaging/watch/watchlist");
 const commonConfig = require("common-display-module");
 const downloadQueue = require("./files/download-queue");
 const config = require("./config/config");
@@ -33,7 +33,7 @@ const initialize = () => {
 initialize()
   .then(database.start)
   .then(messaging.init)
-  .then(refreshAllWatchEntries)
+  .then(watchlist.requestWatchlistCompare)
   .then(downloadQueue.checkStaleFiles)
   .then(()=>{
     const version = config.getModuleVersion();

--- a/src/messaging/update/update.js
+++ b/src/messaging/update/update.js
@@ -2,6 +2,11 @@ const db = require("../../db/api");
 const entry = require("./entry");
 
 module.exports = {
+  updateWatchlistAndMetadata(dbEntry) {
+    const actions = [db.fileMetadata.put, db.watchlist.put];
+
+    return Promise.all(actions.map(action => action(dbEntry)));
+  },
   update(message) {
     const {filePath, version, token} = message;
     log.file(`Received updated version ${version} for ${filePath}`);
@@ -11,11 +16,9 @@ module.exports = {
       return Promise.reject(new Error("Invalid add/update message"));
     }
 
-    return Promise.all([db.fileMetadata.put, db.watchlist.put].map((action) => {
-      const dbEntry = {filePath, version, token, status: "STALE"};
-
-      return action(dbEntry);
-    }))
+    return module.exports.updateWatchlistAndMetadata({
+      filePath, version, token, status: "STALE"
+    });
   },
   process(message) {
     return module.exports.update(message)

--- a/src/messaging/watch/refresh-all.js
+++ b/src/messaging/watch/refresh-all.js
@@ -1,8 +1,0 @@
-const watch = require("./watch");
-const db = require("../../db/api");
-
-module.exports = ()=>{
-  log.file("Refreshing watched files");
-  db.fileMetadata.setAll({status: "UNKNOWN"});
-  db.watchlist.allEntries().forEach(watch.process);
-}

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -1,7 +1,8 @@
-const broadcastIPC = require("../broadcast-ipc.js");
+const broadcastIPC = require("../broadcast-ipc");
 const commonMessaging = require("common-display-module/messaging");
 const db = require("../../db/api");
 const entry = require("./entry");
+const update = require("../update/update");
 
 module.exports = {
   process(message) {
@@ -41,8 +42,7 @@ module.exports = {
 
     const status = token ? "STALE" : "CURRENT";
 
-    return db.fileMetadata.put({filePath, version, status, token})
-    .then(db.watchlist.put({filePath, version}))
+    return update.updateWatchlistAndMetadata({filePath, version, status, token})
     .then(()=>{
       broadcastIPC.fileUpdate({filePath, status, version});
     });

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -8,7 +8,7 @@ module.exports = {
   process(message) {
     const {filePath, from} = message;
 
-    log.file(`Recieved watch for ${filePath}`);
+    log.file(`Received watch for ${filePath}`);
 
     if (!entry.validate({filePath, owner: from})) {
       return Promise.reject(new Error("Invalid watch message"));
@@ -20,7 +20,7 @@ module.exports = {
       metaData.status = metaData.status || "UNKNOWN";
 
       if (metaData.status === "UNKNOWN") {
-        return requestMSUpdate(message, metaData);
+        return module.exports.requestMSUpdate(message, metaData);
       }
 
       return Promise.resolve(broadcastIPC.fileUpdate({
@@ -46,15 +46,14 @@ module.exports = {
     .then(()=>{
       broadcastIPC.fileUpdate({filePath, status, version});
     });
+  },
+  requestMSUpdate(message, metaData) {
+    const msMessage = Object.assign({}, message, {version: metaData.version || "0"});
+    metaData.status = metaData.status === "UNKNOWN" ? "PENDING" : metaData.status;
+
+    return db.fileMetadata.put(metaData)
+    .then(()=>{
+      commonMessaging.sendToMessagingService(msMessage);
+    });
   }
 };
-
-function requestMSUpdate(message, metaData) {
-  const msMessage = Object.assign({}, message, {version: metaData.version || "0"});
-  metaData.status = metaData.status === "UNKNOWN" ? "PENDING" : metaData.status;
-
-  return db.fileMetadata.put(metaData)
-  .then(()=>{
-    commonMessaging.sendToMessagingService(msMessage);
-  });
-}

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -19,7 +19,7 @@ function withUnknownStatus(metaData) {
 }
 
 function refreshUpdatedFile(metaData) {
-  const message = {filePath: metaData.filePath};
+  const message = {topic: "WATCH", filePath: metaData.filePath};
   const updatedMetaData = withUnknownStatus(metaData);
 
   return watch.requestMSUpdate(message, updatedMetaData);

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -12,6 +12,8 @@ function requestWatchlistCompare() {
 function addNewFile(filePath) {
   // obtain owner from parent folder, and register the new file, in a following PR
   log.debug(filePath);
+
+  return Promise.resolve();
 }
 
 function withUnknownStatus(metaData) {
@@ -53,8 +55,8 @@ function refresh(watchlist, lastChanged) {
       return addNewFile(filePath);
     }
 
-    return version === metaData.version ||
-      refreshUpdatedFile(metaData);
+    return version === metaData.version ?
+      Promise.resolve() : refreshUpdatedFile(metaData);
   }))
   .then(() => markMissingFilesAsUnknown(watchlist))
   .then(() => db.watchlist.setLastChanged(lastChanged));

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -1,6 +1,6 @@
 const commonMessaging = require("common-display-module/messaging");
 const db = require("../../db/api");
-const update = require("../update/update");
+const watch = require("./watch");
 
 function requestWatchlistCompare() {
   const lastChanged = db.watchlist.lastChanged();
@@ -14,10 +14,15 @@ function addNewFile(filePath) {
   log.debug(filePath);
 }
 
-function markUpdatedFileAsStale(metaData, version) {
-  const updatedMetaData = Object.assign({}, metaData, {version});
+function withUnknownStatus(metaData) {
+  return Object.assign({}, metaData, {status: "UNKNOWN"});
+}
 
-  return update.update(updatedMetaData);
+function refreshUpdatedFile(metaData) {
+  const message = {filePath: metaData.filePath};
+  const updatedMetaData = withUnknownStatus(metaData);
+
+  return watch.requestMSUpdate(message, updatedMetaData);
 }
 
 function markMissingFilesAsUnknown(remoteWatchlist) {
@@ -27,7 +32,7 @@ function markMissingFilesAsUnknown(remoteWatchlist) {
     .filter(entry => !remoteWatchlist[entry.filePath])
     .map(entry => {
       const metaData = db.fileMetadata.get(entry.filePath);
-      const updatedMetaData = Object.assign({}, metaData, {status: "UNKNOWN"});
+      const updatedMetaData = withUnknownStatus(metaData);
 
       return db.fileMetadata.put(updatedMetaData);
   }));
@@ -49,7 +54,7 @@ function refresh(watchlist, lastChanged) {
     }
 
     return version === metaData.version ||
-      markUpdatedFileAsStale(metaData, version);
+      refreshUpdatedFile(metaData);
   }))
   .then(() => markMissingFilesAsUnknown(watchlist))
   .then(() => db.watchlist.setLastChanged(lastChanged));

--- a/test/integration/db/lokijs/database.js
+++ b/test/integration/db/lokijs/database.js
@@ -112,7 +112,7 @@ describe("lokijs - integration", ()=>{
   it("returns a default last changed value", ()=>{
     const defaultValue = db.watchlist.lastChanged();
 
-    assert.equal(defaultValue, 0);
+    assert.equal(defaultValue, '0');
   });
 
   it("sets the last changed value", ()=>{
@@ -128,7 +128,7 @@ describe("lokijs - integration", ()=>{
 
     const lastChanged = db.watchlist.lastChanged();
 
-    assert.equal(lastChanged, 0);
+    assert.equal(lastChanged, '0');
   });
 
   it("doesn't let to set lastChanged value to a less value than its current value", ()=>{

--- a/test/integration/db/lokijs/database.js
+++ b/test/integration/db/lokijs/database.js
@@ -116,11 +116,11 @@ describe("lokijs - integration", ()=>{
   });
 
   it("sets the last changed value", ()=>{
-    db.watchlist.setLastChanged(123456);
+    db.watchlist.setLastChanged("123456");
 
     const lastChanged = db.watchlist.lastChanged();
 
-    assert.equal(lastChanged, 123456);
+    assert.equal(lastChanged, "123456");
   });
 
   it("sets the last changed value as undefined", ()=>{
@@ -129,5 +129,16 @@ describe("lokijs - integration", ()=>{
     const lastChanged = db.watchlist.lastChanged();
 
     assert.equal(lastChanged, 0);
+  });
+
+  it("doesn't let to set lastChanged value to a less value than it's current value", ()=>{
+    db.watchlist.setLastChanged("123456");
+    db.watchlist.setLastChanged("12345");
+    db.watchlist.setLastChanged("1234");
+    db.watchlist.setLastChanged("34");
+
+    const lastChanged = db.watchlist.lastChanged();
+
+    assert.equal(lastChanged, "123456");
   });
 });

--- a/test/integration/db/lokijs/database.js
+++ b/test/integration/db/lokijs/database.js
@@ -131,7 +131,7 @@ describe("lokijs - integration", ()=>{
     assert.equal(lastChanged, 0);
   });
 
-  it("doesn't let to set lastChanged value to a less value than it's current value", ()=>{
+  it("doesn't let to set lastChanged value to a less value than its current value", ()=>{
     db.watchlist.setLastChanged("123456");
     db.watchlist.setLastChanged("12345");
     db.watchlist.setLastChanged("1234");

--- a/test/integration/messaging/watch/watchlist.js
+++ b/test/integration/messaging/watch/watchlist.js
@@ -62,19 +62,13 @@ describe("watchlist - integration", ()=>{
   describe("WATCHLIST-RESULT", () => {
     function fillDatabase() {
       db.fileMetadata.put({
-        filePath: "bucket/file1", status: "CURRENT", version: "1", token: {
-          hash: "xxxx", data: {}
-        }
+        filePath: "bucket/file1", status: "CURRENT", version: "1"
       });
       db.fileMetadata.put({
-        filePath: "bucket/file2", status: "CURRENT", version: "2", token: {
-          hash: "yyyy", data: {}
-        }
+        filePath: "bucket/file2", status: "CURRENT", version: "2"
       });
       db.fileMetadata.put({
-        filePath: "bucket/file3", status: "CURRENT", version: "3", token: {
-          hash: "zzzz", data: {}
-        }
+        filePath: "bucket/file3", status: "CURRENT", version: "3"
       });
 
       db.watchlist.put({filePath: "bucket/file1", version: "1"});
@@ -98,29 +92,35 @@ describe("watchlist - integration", ()=>{
       return watchlist.refresh(remoteWatchlist, 123456)
       .then(() => {
         const metaDataList = db.fileMetadata.allEntries()
-        .map(({filePath, status, version, token}) =>
-          ({filePath, status, version, token})
+        .map(({filePath, status, version}) =>
+          ({filePath, status, version})
         );
 
         assert.deepEqual(metaDataList, [
           {
-            filePath: "bucket/file1", status: "STALE", version: "2", token: {
-              hash: "xxxx", data: {}
-            }
+            filePath: "bucket/file1", status: "PENDING", version: "1"
           },
           {
-            filePath: "bucket/file2", status: "STALE", version: "3", token: {
-              hash: "yyyy", data: {}
-            }
+            filePath: "bucket/file2", status: "PENDING", version: "2"
           },
           {
-            filePath: "bucket/file3", status: "CURRENT", version: "3", token: {
-              hash: "zzzz", data: {}
-            }
+            filePath: "bucket/file3", status: "CURRENT", version: "3"
           }
         ]);
 
         assert.equal(db.watchlist.lastChanged(), 123456);
+
+        // 2 updates
+        assert.equal(commonMessaging.sendToMessagingService.callCount, 2);
+        commonMessaging.sendToMessagingService.calls.forEach(call =>{
+          const message = call.args[0];
+
+          switch (message.filePath) {
+            case "bucket/file1": return assert.equal(message.version, "1");
+            case "bucket/file2": return assert.equal(message.version, "2");
+            default: assert.fail(message.filePath);
+          }
+        });
       });
     });
 
@@ -135,29 +135,30 @@ describe("watchlist - integration", ()=>{
       return watchlist.refresh(remoteWatchlist, 123456)
       .then(() => {
         const metaDataList = db.fileMetadata.allEntries()
-        .map(({filePath, status, version, token}) =>
-          ({filePath, status, version, token})
+        .map(({filePath, status, version}) =>
+          ({filePath, status, version})
         );
 
         assert.deepEqual(metaDataList, [
           {
-            filePath: "bucket/file1", status: "STALE", version: "2", token: {
-              hash: "xxxx", data: {}
-            }
+            filePath: "bucket/file1", status: "PENDING", version: "1"
           },
           {
-            filePath: "bucket/file2", status: "UNKNOWN", version: "2", token: {
-              hash: "yyyy", data: {}
-            }
+            filePath: "bucket/file2", status: "UNKNOWN", version: "2"
           },
           {
-            filePath: "bucket/file3", status: "CURRENT", version: "3", token: {
-              hash: "zzzz", data: {}
-            }
+            filePath: "bucket/file3", status: "CURRENT", version: "3"
           }
         ]);
 
         assert.equal(db.watchlist.lastChanged(), 123456);
+
+        // 1 update
+        assert.equal(commonMessaging.sendToMessagingService.callCount, 1);
+        assert.deepEqual(commonMessaging.sendToMessagingService.lastCall.args[0], {
+          filePath: "bucket/file1",
+          version: "1"
+        });
       });
     });
 
@@ -173,29 +174,26 @@ describe("watchlist - integration", ()=>{
       return watchlist.refresh(remoteWatchlist, 123456)
       .then(() => {
         const metaDataList = db.fileMetadata.allEntries()
-        .map(({filePath, status, version, token}) =>
-          ({filePath, status, version, token})
+        .map(({filePath, status, version}) =>
+          ({filePath, status, version})
         );
 
         assert.deepEqual(metaDataList, [
           {
-            filePath: "bucket/file1", status: "CURRENT", version: "1", token: {
-              hash: "xxxx", data: {}
-            }
+            filePath: "bucket/file1", status: "CURRENT", version: "1"
           },
           {
-            filePath: "bucket/file2", status: "CURRENT", version: "2", token: {
-              hash: "yyyy", data: {}
-            }
+            filePath: "bucket/file2", status: "CURRENT", version: "2"
           },
           {
-            filePath: "bucket/file3", status: "CURRENT", version: "3", token: {
-              hash: "zzzz", data: {}
-            }
+            filePath: "bucket/file3", status: "CURRENT", version: "3"
           }
         ]);
 
         assert.equal(db.watchlist.lastChanged(), 123456);
+
+        // no updates
+        assert.equal(commonMessaging.sendToMessagingService.callCount, 0);
       });
     });
 
@@ -205,30 +203,27 @@ describe("watchlist - integration", ()=>{
       return watchlist.refresh({}, 123456)
       .then(() => {
         const metaDataList = db.fileMetadata.allEntries()
-        .map(({filePath, status, version, token}) =>
-          ({filePath, status, version, token})
+        .map(({filePath, status, version}) =>
+          ({filePath, status, version})
         );
 
         assert.deepEqual(metaDataList, [
           {
-            filePath: "bucket/file1", status: "CURRENT", version: "1", token: {
-              hash: "xxxx", data: {}
-            }
+            filePath: "bucket/file1", status: "CURRENT", version: "1"
           },
           {
-            filePath: "bucket/file2", status: "CURRENT", version: "2", token: {
-              hash: "yyyy", data: {}
-            }
+            filePath: "bucket/file2", status: "CURRENT", version: "2"
           },
           {
-            filePath: "bucket/file3", status: "CURRENT", version: "3", token: {
-              hash: "zzzz", data: {}
-            }
+            filePath: "bucket/file3", status: "CURRENT", version: "3"
           }
         ]);
 
         // last changed not updated in this scenario
         assert.equal(db.watchlist.lastChanged(), 0);
+
+        // no updates
+        assert.equal(commonMessaging.sendToMessagingService.callCount, 0);
       });
     });
   });

--- a/test/integration/messaging/watch/watchlist.js
+++ b/test/integration/messaging/watch/watchlist.js
@@ -115,6 +115,8 @@ describe("watchlist - integration", ()=>{
         commonMessaging.sendToMessagingService.calls.forEach(call =>{
           const message = call.args[0];
 
+          assert.equal(message.topic, "WATCH");
+
           switch (message.filePath) {
             case "bucket/file1": return assert.equal(message.version, "1");
             case "bucket/file2": return assert.equal(message.version, "2");
@@ -156,6 +158,7 @@ describe("watchlist - integration", ()=>{
         // 1 update
         assert.equal(commonMessaging.sendToMessagingService.callCount, 1);
         assert.deepEqual(commonMessaging.sendToMessagingService.lastCall.args[0], {
+          topic: "WATCH",
           filePath: "bucket/file1",
           version: "1"
         });

--- a/test/unit/db/api.js
+++ b/test/unit/db/api.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable no-magic-numbers */
 
 const assert = require("assert");
 const database = require("../../../src/db/lokijs/database");
@@ -196,6 +197,7 @@ describe("DB API: Unit", ()=> {
       mockCollection = {
         by: simple.stub().returnWith(JSON.parse(JSON.stringify(mockWatchlist))),
         find: simple.stub().returnWith([]),
+        findAndUpdate: simple.stub().returnWith(),
         insert: simple.stub().callFn(entry => entry),
         update: simple.stub().returnWith(),
         remove: simple.stub().returnWith()
@@ -272,6 +274,23 @@ describe("DB API: Unit", ()=> {
       const defaultValue = db.watchlist.lastChanged();
 
       assert.equal(defaultValue, 0);
+    });
+
+    it("sets lastChanged value", ()=> {
+      db.watchlist.setLastChanged("1000");
+
+      assert.equal(mockCollection.findAndUpdate.callCount, 1);
+      assert.deepEqual(mockCollection.findAndUpdate.lastCall.args[1]({}), {
+        lastChanged: "1000"
+      });
+    });
+
+    it("doesn't let change lastChanged to a value less that its current one", ()=> {
+      simple.mock(db.watchlist, "lastChanged").returnWith(1000);
+
+      db.watchlist.setLastChanged("100");
+
+      assert(!mockCollection.findAndUpdate.called);
     });
   });
 });

--- a/test/unit/db/api.js
+++ b/test/unit/db/api.js
@@ -273,7 +273,7 @@ describe("DB API: Unit", ()=> {
     it("gets default lastChanged value as 0", ()=> {
       const defaultValue = db.watchlist.lastChanged();
 
-      assert.equal(defaultValue, 0);
+      assert.equal(defaultValue, "0");
     });
 
     it("sets lastChanged value", ()=> {

--- a/test/unit/messaging/watch/watch.js
+++ b/test/unit/messaging/watch/watch.js
@@ -239,7 +239,10 @@ describe("Messaging", ()=>{
         })
         .then(()=>{
           assert(db.watchlist.put.called);
-          assert.deepEqual(db.watchlist.put.lastCall.args[0], {filePath: msg.filePath, version: msg.version});
+
+          const entry = db.watchlist.put.lastCall.args[0];
+          assert.equal(entry.filePath, msg.filePath);
+          assert.equal(entry.version, msg.version);
         })
         .then(()=>{
           assert(broadcastIPC.fileUpdate.called);
@@ -271,7 +274,10 @@ describe("Messaging", ()=>{
       })
       .then(()=>{
         assert(db.watchlist.put.called);
-        assert.deepEqual(db.watchlist.put.lastCall.args[0], {filePath: msg.filePath, version: msg.version});
+
+        const entry = db.watchlist.put.lastCall.args[0];
+        assert.equal(entry.filePath, msg.filePath);
+        assert.equal(entry.version, msg.version);
       })
       .then(()=>{
         assert.equal(broadcastIPC.fileUpdate.callCount, 1);

--- a/test/unit/messaging/watch/watchlist.js
+++ b/test/unit/messaging/watch/watchlist.js
@@ -6,7 +6,7 @@ const simple = require("simple-mock");
 const commonMessaging = require("common-display-module/messaging");
 
 const db = require("../../../../src/db/api");
-const update = require("../../../../src/messaging/update/update");
+const watch = require("../../../../src/messaging/watch/watch");
 const watchlist = require("../../../../src/messaging/watch/watchlist");
 
 global.log = {file: ()=>{}, debug: ()=>{}, error: ()=>{}, all: () => {}};
@@ -37,7 +37,7 @@ describe("watchlist - unit", () => {
       simple.mock(db.owners, "get").returnWith({owners: ['licensing']});
       simple.mock(db.fileMetadata, "put").resolveWith();
       simple.mock(db.watchlist, "setLastChanged").returnWith();
-      simple.mock(update, "update").resolveWith();
+      simple.mock(watch, "requestMSUpdate").resolveWith();
     });
 
     it("refreshes the watchlist when there are changes", () => {
@@ -61,16 +61,18 @@ describe("watchlist - unit", () => {
       return watchlist.refresh(remoteWatchlist, 123456)
       .then(() => {
         // two files were updated
-        assert.equal(update.update.callCount, 2);
-        update.update.calls.forEach(call =>{
-          const entry = call.args[0];
+        assert.equal(watch.requestMSUpdate.callCount, 2);
+        watch.requestMSUpdate.calls.forEach(call =>{
+          const message = call.args[0];
+          const metaData = call.args[1];
 
-          assert.equal(entry.status, "CURRENT");
+          assert.deepEqual(message, {filePath: metaData.filePath});
+          assert.equal(metaData.status, "UNKNOWN");
 
-          switch (entry.filePath) {
-            case "bucket/file1": return assert.equal(entry.version, "2");
-            case "bucket/file2": return assert.equal(entry.version, "3");
-            default: assert.fail(entry.filePath);
+          switch (metaData.filePath) {
+            case "bucket/file1": return assert.equal(metaData.version, "1");
+            case "bucket/file2": return assert.equal(metaData.version, "2");
+            default: assert.fail(metaData.filePath);
           }
         });
 
@@ -102,9 +104,14 @@ describe("watchlist - unit", () => {
       return watchlist.refresh(remoteWatchlist, 123456)
       .then(() => {
         // just one file was updated
-        assert.equal(update.update.callCount, 1);
-        assert.deepEqual(update.update.lastCall.args[0], {
-          filePath: "bucket/file1", status: "CURRENT", version: "2"
+        assert.equal(watch.requestMSUpdate.callCount, 1);
+        assert.deepEqual(watch.requestMSUpdate.lastCall.args[0], {
+          filePath: "bucket/file1"
+        });
+        assert.deepEqual(watch.requestMSUpdate.lastCall.args[1], {
+          filePath: "bucket/file1",
+          status: "UNKNOWN",
+          version: "1"
         });
 
         // one file was deleted
@@ -138,7 +145,7 @@ describe("watchlist - unit", () => {
 
       return watchlist.refresh(remoteWatchlist, 123456)
       .then(() => {
-        assert(!update.update.called);
+        assert(!watch.requestMSUpdate.called);
         assert(!db.fileMetadata.put.called);
 
         assert.equal(db.watchlist.setLastChanged.callCount, 1);
@@ -160,7 +167,7 @@ describe("watchlist - unit", () => {
 
       return watchlist.refresh({}, 123456)
       .then(() => {
-        assert(!update.update.called);
+        assert(!watch.requestMSUpdate.called);
         assert(!db.fileMetadata.put.called);
         assert(!db.watchlist.setLastChanged.called);
       });

--- a/test/unit/messaging/watch/watchlist.js
+++ b/test/unit/messaging/watch/watchlist.js
@@ -66,7 +66,9 @@ describe("watchlist - unit", () => {
           const message = call.args[0];
           const metaData = call.args[1];
 
-          assert.deepEqual(message, {filePath: metaData.filePath});
+          assert.deepEqual(message, {
+            topic: "WATCH", filePath: metaData.filePath
+          });
           assert.equal(metaData.status, "UNKNOWN");
 
           switch (metaData.filePath) {
@@ -106,6 +108,7 @@ describe("watchlist - unit", () => {
         // just one file was updated
         assert.equal(watch.requestMSUpdate.callCount, 1);
         assert.deepEqual(watch.requestMSUpdate.lastCall.args[0], {
+          topic: "WATCH",
           filePath: "bucket/file1"
         });
         assert.deepEqual(watch.requestMSUpdate.lastCall.args[1], {


### PR DESCRIPTION
This replaces the old refresh-all with a watchlist compare.

I also did some manual testing against staged MS changing files and checking lastChanged, watchlist, watch and file-update messages being sent and received accordingly.
