### PR TITLE
return reject instead of throwing error

### DIFF
--- a/src/messaging/add/add.js
+++ b/src/messaging/add/add.js
@@ -10,10 +10,11 @@ module.exports = {
     const folderItem = db.owners.get(folderPath);
 
     if (!folderItem) {
-      throw new Error(`No owners registered for folder ${folderPath}`);
+      return Promise.reject(new Error(`No owners registered for folder ${folderPath}`));
     }
 
     db.owners.put({filePath, owners: folderItem.owners});
+    return Promise.resolve();
   },
   process(message) {
     return update.validate(message, "add")

--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -22,9 +22,8 @@ function handleFolderWatchResult(message) {
   const {folderData} = message;
 
   return Promise.all(folderData.map(fileData => {
-    addition.assignOwnersOfParentDirectory(fileData);
-
-    return handleFileWatchResult(fileData);
+    return addition.assignOwnersOfParentDirectory(fileData)
+    .then(() => handleFileWatchResult(fileData));
   }));
 }
 

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -14,9 +14,8 @@ function requestWatchlistCompare() {
 function addNewFile(filePath) {
   const metaData = {filePath, version: '0', status: "UNKNOWN"};
 
-  addition.assignOwnersOfParentDirectory(metaData);
-
-  return update.updateWatchlistAndMetadata(metaData)
+  return addition.assignOwnersOfParentDirectory(metaData)
+  .then(() => update.updateWatchlistAndMetadata(metaData))
   .then(() => refreshUpdatedFile(metaData));
 }
 

--- a/test/integration/messaging/add.js
+++ b/test/integration/messaging/add.js
@@ -54,19 +54,21 @@ describe("ADD - integration", ()=>{
 
     fillDatabase();
 
-    addition.assignOwnersOfParentDirectory({filePath});
+    return addition.assignOwnersOfParentDirectory({filePath})
+    .then(() => {
+      const item = db.owners.get(filePath);
 
-    const item = db.owners.get(filePath);
-
-    assert(item);
-    assert(item.owners);
-    assert.deepEqual(item.owners, ["licensing", "display-control"]);
+      assert(item);
+      assert(item.owners);
+      assert.deepEqual(item.owners, ["licensing", "display-control"]);
+    });
   });
 
   it("fails if there is no owner registered for parent directory", () => {
     const filePath = "bucket/directory/file1";
 
-    assert.throws(() => addition.assignOwnersOfParentDirectory({filePath}), Error);
+    return addition.assignOwnersOfParentDirectory({filePath})
+    .then(() => assert.fail(), () => {});
   });
 
   it("adds a file to the database", () => {


### PR DESCRIPTION
This is causing local storage to crash in e2e tests, and maybe also in two other beta displays.

Apparently throwing an error conflicts with map or Promise.all() and a rejected promise should be used instead.
