### PR TITLE
Broadcast FILE-UPDATE with STALE status on file update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,7 +1692,7 @@
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
-        "env-variable": "0.0.3"
+        "env-variable": "0.0.4"
       }
     },
     "encoding": {
@@ -1724,9 +1724,9 @@
       }
     },
     "env-variable": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
-      "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s=",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
+      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg==",
       "dev": true
     },
     "errno": {
@@ -2192,9 +2192,9 @@
       "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ=="
     },
     "eventemitter3": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.0.tgz",
-      "integrity": "sha512-62TxCtz4m2LRaOERVEvLJJ4A6rsg8lC9Xm+FLg2y/1fB/v4ZZ9JCOn+/Ppl5KkH6sRih6bhix724PVanmXYZJQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
+      "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
       "dev": true
     },
     "events": {
@@ -3812,6 +3812,12 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
+    "ignore-loader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
+      "integrity": "sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4353,12 +4359,14 @@
       }
     },
     "local-messaging-module": {
-      "version": "git+https://github.com/Rise-Vision/local-messaging-module.git#775d2bcabfba95397595270086e32c9533958604",
+      "version": "git+https://github.com/Rise-Vision/local-messaging-module.git#660dff9f4e22f01b274ab189ce277b59a98e930a",
       "dev": true,
       "requires": {
-        "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#b4665220677186bb1776d414362fa54db6d94b04",
-        "node-ipc": "9.1.1",
+        "clean-webpack-plugin": "0.1.18",
+        "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#efd5365e2508d52078c83320866dc95e1dc25f54",
+        "ignore-loader": "0.1.2",
         "primus": "7.1.1",
+        "rise-common-electron": "git://github.com/Rise-Vision/rise-common-electron.git#fe8fd2a4818d828605f2a4dc8c3142d3c6c3e341",
         "ws": "3.3.3"
       },
       "dependencies": {
@@ -4373,13 +4381,13 @@
           }
         },
         "common-display-module": {
-          "version": "git://github.com/Rise-Vision/common-display-module.git#b4665220677186bb1776d414362fa54db6d94b04",
+          "version": "git://github.com/Rise-Vision/common-display-module.git#efd5365e2508d52078c83320866dc95e1dc25f54",
           "dev": true,
           "requires": {
             "https-proxy-agent": "2.1.1",
             "node-ipc": "9.1.1",
             "proxy-agent": "2.2.0",
-            "rise-common-electron": "git://github.com/Rise-Vision/rise-common-electron.git#467d4c639ee1826961b5f7717f463ce9bd324b23"
+            "rise-common-electron": "git://github.com/Rise-Vision/rise-common-electron.git#fe8fd2a4818d828605f2a4dc8c3142d3c6c3e341"
           }
         },
         "debug": {
@@ -4412,12 +4420,8 @@
             }
           }
         },
-        "graceful-fs": {
-          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-          "dev": true
-        },
         "rise-common-electron": {
-          "version": "git://github.com/Rise-Vision/rise-common-electron.git#467d4c639ee1826961b5f7717f463ce9bd324b23",
+          "version": "git://github.com/Rise-Vision/rise-common-electron.git#fe8fd2a4818d828605f2a4dc8c3142d3c6c3e341",
           "dev": true,
           "requires": {
             "fs-extra": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
@@ -5301,7 +5305,7 @@
         "asyncemit": "3.0.1",
         "create-server": "1.0.1",
         "diagnostics": "1.1.0",
-        "eventemitter3": "3.0.0",
+        "eventemitter3": "3.0.1",
         "forwarded-for": "1.0.1",
         "fusing": "1.0.0",
         "setheader": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "local-messaging-module": "git+https://github.com/Rise-Vision/local-messaging-module.git#775d2",
+    "local-messaging-module": "git+https://github.com/Rise-Vision/local-messaging-module.git#660dff9",
     "mocha": "^4.0.0",
     "mock-fs": "^4.4.2",
     "nock": "^9.1.2",

--- a/src/messaging/update/update.js
+++ b/src/messaging/update/update.js
@@ -1,5 +1,6 @@
 const db = require("../../db/api");
 const entry = require("./entry");
+const broadcastIPC = require("../broadcast-ipc");
 
 module.exports = {
   updateWatchlistAndMetadata(dbEntry) {
@@ -12,6 +13,9 @@ module.exports = {
 
     return module.exports.updateWatchlistAndMetadata({
       filePath, version, token, status: "STALE"
+    })
+    .then(()=>{
+      broadcastIPC.fileUpdate({filePath, status: "STALE", version});
     })
     .then(() => db.watchlist.setLastChanged(message.watchlistLastChanged));
   },

--- a/test/integration/messaging/messaging.js
+++ b/test/integration/messaging/messaging.js
@@ -10,6 +10,7 @@ const os = require("os");
 const messaging = require("../../../src/messaging/messaging");
 const database = require("../../../src/db/lokijs/database");
 const api = require("../../../src/db/api");
+const ipc = require("node-ipc");
 const localMessagingModule = require("local-messaging-module");
 const path = require("path");
 const {platform} = require("rise-common-electron");
@@ -36,12 +37,15 @@ describe("WATCH: Integration", function() {
       simple.mock(commonConfig, "getModulePath").returnWith(tempModulePath);
       simple.mock(fileSystem, "getCacheDir").returnWith(tempCacheDir);
 
+      ipc.config.id = "lms";
+      ipc.config.retry = 1500;
+
       return platform.mkdirRecursively(tempDBPath)
       .then(()=>platform.mkdirRecursively(tempModulePath))
       .then(()=>platform.mkdirRecursively(tempCacheDir))
       .then(()=>platform.mkdirRecursively(fileSystem.getDownloadDir()))
       .then(()=>platform.mkdirRecursively(fileSystem.getCacheDir()))
-      .then(()=>localMessagingModule.start("ls-test-did", "ls-test-mid"))
+      .then(()=>localMessagingModule.start(ipc, "ls-test-did", "ls-test-mid"))
       .then(()=>database.start(tempDBPath, dbSaveInterval))
       .then(messaging.init);
     });


### PR DESCRIPTION
A client side widget/component at the moment only receives FILE-UPDATE with status CURRENT when a file has been updated. This isn't clear and indicative that a file was updated. It could result in unnecessary reloading of a file. 

If previous FILE-UPDATE status was STALE and the next FILE-UPDATE status is CURRENT, it's evident there's an updated version of the file available and therefore a widget/component can confidently reload the file. This PR initiates that.