### PR TITLE
Fix failing assertion in messaging integration test

### DIFF
--- a/test/integration/messaging/messaging.js
+++ b/test/integration/messaging/messaging.js
@@ -147,19 +147,23 @@ describe("WATCH: Integration", function() {
         filePath
       });
 
-      return new Promise(res=>{
-        commonMessaging.receiveMessages("test")
-          .then(receiver=>receiver.on("message", (message)=>{
-            if (message.topic === "FILE-UPDATE") {
-              assert.equal(message.status, "DELETED");
-              assert(!api.fileMetadata.get(filePath));
-              assert(!api.watchlist.get(filePath));
-              assert.equal(api.watchlist.lastChanged(), "2522697262234");
+      const delay = 200;
 
-              res();
-            }
-          }));
-      });
+      setTimeout(()=>{
+        return new Promise(res=>{
+          commonMessaging.receiveMessages("test")
+            .then(receiver=>receiver.on("message", (message)=>{
+              if (message.topic === "FILE-UPDATE") {
+                assert.equal(message.status, "DELETED");
+                assert(!api.fileMetadata.get(filePath));
+                assert(!api.watchlist.get(filePath));
+                assert.equal(api.watchlist.lastChanged(), "2522697262234");
+
+                res();
+              }
+            }));
+        });
+      }, delay);
     });
 
     it("should receive MSFILEUPDATE from MS for an added file to a folder and update DB", function(done) {


### PR DESCRIPTION
@santiagonoguez A delay is required so that the current message being sent is received. This fixes the failing assertion. 