### PR TITLE
Provide local file url in FILE-UPDATE broadcast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,6 +2394,11 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
+    "file-url": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
+      "integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4="
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "common-display-module": "git://github.com/Rise-Vision/common-display-module.git#v3.0.6",
+    "file-url": "^2.0.2",
     "fs-extra": "^4.0.2",
     "gcs-filepath-validator": "^1.0.0",
     "lokijs": "^1.5.1",

--- a/src/files/file-system.js
+++ b/src/files/file-system.js
@@ -3,6 +3,7 @@ const crypto = require("crypto");
 const path = require("path");
 const platform = require("rise-common-electron").platform;
 const fs = require("fs-extra");
+const fileUrl = require("file-url");
 const config = require("../../src/config/config");
 
 const DIR_CACHE = "cache";
@@ -47,6 +48,11 @@ module.exports = {
     const cacheDir = module.exports.getCacheDir();
 
     return path.join(cacheDir, fileName);
+  },
+  getLocalFileUrl(filePath, version = "") {
+    const pathInCache = module.exports.getPathInCache(filePath, version);
+
+    return fileUrl(pathInCache, {resolve: false});
   },
   isProcessing(fileName) {
     return processingList.has(fileName);

--- a/src/messaging/broadcast-ipc.js
+++ b/src/messaging/broadcast-ipc.js
@@ -20,7 +20,10 @@ module.exports = {
   },
   fileUpdate(data = {}) {
     log.file(`Broadcasting ${data.status} FILE-UPDATE for ${data.filePath}`);
-    const ospath = {ospath: fileSystem.getPathInCache(data.filePath, data.version)};
+    const ospath = {
+      ospath: fileSystem.getPathInCache(data.filePath, data.version),
+      osurl: fileSystem.getLocalFileUrl(data.filePath, data.version)
+    };
     const messageObj = Object.assign({}, data, data.version ? ospath : {});
     module.exports.broadcast("FILE-UPDATE", messageObj);
   },

--- a/test/unit/files/file-system.js
+++ b/test/unit/files/file-system.js
@@ -39,6 +39,12 @@ describe("File System", ()=> {
     });
   });
 
+  describe("getLocalFileUrl", () => {
+    it("should provide local file url for a file in cache given a gcs filePath", ()=> {
+      assert.equal(fileSystem.getLocalFileUrl(testFilePath), `file:///${expectedDataPath}cache/e498da09daba1d6bb3c6e5c0f0966784`);
+    });
+  });
+
   describe("getFileName", () => {
     it("should return an empty string if no file path provided", () => {
       assert.equal(fileSystem.getFileName(), "");

--- a/test/unit/messaging/broadcast-ipc.js
+++ b/test/unit/messaging/broadcast-ipc.js
@@ -29,6 +29,7 @@ describe("Broadcast IPC", ()=> {
       filePath: "test-file-path",
       version: "12345",
       ospath: "fake-os-path",
+      osurl: "file:///fake-os-path",
       status: "test-status"
     });
   });
@@ -45,6 +46,7 @@ describe("Broadcast IPC", ()=> {
       filePath: "test-file-path",
       version: "12345",
       ospath: "fake-os-path",
+      osurl: "file:///fake-os-path",
       status: "test-status"
     });
   });


### PR DESCRIPTION
- New prop `osurl` provided in FILE-UPDATE broadcast with value appropriate for browser running on applicable os platform 
- Existing prop `ospath` remains unchanged to support existing modules dependent on it 
- Tested staged version of local-storage module with staged widget. Working on both Ubuntu 14.04 x32 and Win 10 x32. 