### PR TITLE
Fix error where entry is in the watch list but not in the file metadata

### DIFF
--- a/src/db/lokijs/database.js
+++ b/src/db/lokijs/database.js
@@ -54,8 +54,8 @@ function syncCacheMetadataWithFileSystem() {
       return cached.indexOf(pathInCache) < 0;
     })
     .forEach(entry => {
-      logger.file(JSON.stringify(entry), "File not found in cache dir. Removing it from database");
-      metadata.remove(entry)
+      logger.file(JSON.stringify(entry), "File not found in cache dir. Marking it as unknown in the database");
+      metadata.update(Object.assign({}, entry, {status: "UNKNOWN", version: "0"}));
     });
   })
   .catch(() => logger.warning("Error when reading cache dir to sync metadata database"));


### PR DESCRIPTION
  - Do not remove entries from file metadata
  - Set entries status to "UNKNOWN" and version to "0" when the file got removed from file system but the metadata is set as CURRENT in the database