### PR TITLE
Do not override error message from MS

### DIFF
--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -55,10 +55,10 @@ module.exports = {
     });
   },
   msResult(message) {
-    const {filePath, error, folderData, watchlistLastChanged} = message;
+    const {filePath, errorCode, errorMsg, folderData, watchlistLastChanged} = message;
 
-    if (error) {
-      broadcastIPC.fileUpdate({filePath, status: "NOEXIST"});
+    if (errorCode || errorMsg) {
+      broadcastIPC.fileUpdate({filePath, status: errorMsg || errorCode});
       return Promise.resolve();
     }
 

--- a/test/unit/messaging/watch/watch.js
+++ b/test/unit/messaging/watch/watch.js
@@ -197,7 +197,7 @@ describe("Watch - Unit", ()=>{
     });
 
     it("should broadcast FILEUPDATE with NOEXIST status when error providing from MS", ()=>{
-      const msg = Object.assign({}, mockMessage, {error: 404});
+      const msg = Object.assign({}, mockMessage, {errorMsg: "NOEXIST"});
 
       return messageReceiveHandler(msg)
         .then(()=>{


### PR DESCRIPTION
**NOEXIST** is not the only failure case from MS WATCH RESULT so it should not be forced as the error status.

