### PR TITLE
A file might be in the watchlist db but not in the fileMetadata db yet.

### DIFF
--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -39,8 +39,9 @@ function markMissingFilesAsUnknown(remoteWatchlist) {
 
   return Promise.all(localWatchlist
     .filter(entry => !remoteWatchlist[entry.filePath])
-    .map(entry => {
-      const metaData = db.fileMetadata.get(entry.filePath);
+    .map(entry => db.fileMetadata.get(entry.filePath))
+    .filter(entry => entry && entry.filePath)
+    .map(metaData => {
       const updatedMetaData = withUnknownStatus(metaData);
 
       return db.fileMetadata.put(updatedMetaData);


### PR DESCRIPTION
Follow up from investigating the error that started on the last release for local-storage.

File is in the local watchlist but not in the metadata db.
This is causing an exception when we try to update metadata.

@Rise-Vision/delivery please review