### PR TITLE
Update on add even for single-file watchers

### DIFF
--- a/src/messaging/add/add.js
+++ b/src/messaging/add/add.js
@@ -4,6 +4,6 @@ module.exports = {
   process(message) {
     return update.validate(message, "add")
     .then(()=>update.assignOwnersOfParentDirectory(message, 'MSFILEUPDATE'))
-    .then(assigned => assigned && update.update(message));
+    .then(()=>update.update(message));
   }
 };


### PR DESCRIPTION
This ensures that update is called even when there are no folder
watchers. There may be some single-file watchers.

Example use case:

 - while online
 - a file is being shown by a single-file image widget
 - the file is deleted to trash
 - the file is no longer shown
 - the file is restored from trash
 - the file will now be shown whereas without this fix it is not

Before calling `update` we could run a db check to make sure there are
some watchers, but it's simpler to go ahead and process the upgrade
regardless. The overhead is minimal.