### PR TITLE
Correct logger.all call

### DIFF
--- a/src/messaging/messaging.js
+++ b/src/messaging/messaging.js
@@ -39,7 +39,7 @@ const handleMSFileUpdate = (message) => {
 
   if (!action) {return;}
 
-  logger.all(`MS file ${type} received`, {file_path: message.filePath});
+  logger.all(`MS file ${type} received`, message.filePath);
 
   return action.process(message)
   .catch(err => {


### PR DESCRIPTION
If an object is supplied it requires an "event_details" property.