### PR TITLE
Store folder version metadata

### DIFF
--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -55,7 +55,7 @@ function processFolderWatch(message, existingMetadata) {
   }
 
   logger.file(`Requesting MS update for folder ${folderPath}`);
-  return requestMSUpdate(message, {filePath: folderPath});
+  return requestMSUpdate(message, {filePath: folderPath, version: "0"});
 }
 
 function requestMSUpdate(message, metaData) {


### PR DESCRIPTION
Without version metadata, whenever a watchlist is out of sync
(lastChanged does not match MS) the folder metadata entry will be
deleted. This is because MS sends version "0" for folders and
version "0" indicates MS-side deletion unless the version matches,
in which case the files are considered up to date and no deletion
will occur.

So without a version "0" for folder metadata, the folder version is
mismatched and a new folder-watch will be submitted to MS. This results
in a new set of tokens in the response and this will result in all
files being re-downloaded.