### PR TITLE
Resubmit WATCH for empty folders

### DIFF
--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -47,11 +47,20 @@ function processFileWatch(message, existingMetadata) {
 
 function processFolderWatch(message, existingMetadata) {
   const folderPath = message.filePath;
+
   if (existingMetadata) {
     const folderFiles = db.fileMetadata.getFolderFiles(folderPath);
-    logger.file(JSON.stringify(folderFiles), `Processing watch for existing folder ${folderPath}`);
-    const promises = folderFiles.map(fileMetadata => processFileWatch({filePath: fileMetadata.filePath, topic: 'watch'}, fileMetadata));
-    return Promise.all(promises);
+
+    if (folderFiles.length > 0) {
+      logger.file(JSON.stringify(folderFiles), `Processing watch for existing folder ${folderPath}`);
+
+      const promises = folderFiles.map(fileMetadata => processFileWatch({
+        filePath: fileMetadata.filePath,
+        topic: 'watch'
+      }, fileMetadata));
+
+      return Promise.all(promises);
+    }
   }
 
   logger.file(`Requesting MS update for folder ${folderPath}`);

--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -3,11 +3,13 @@ const db = require("../../db/api");
 const update = require("../update/update");
 const del = require("../delete/delete");
 const watch = require("./watch");
+const logger = require("../../logger");
 
 function requestWatchlistCompare() {
   const lastChanged = db.watchlist.lastChanged();
   const msMessage = {topic: "WATCHLIST-COMPARE", lastChanged};
 
+  logger.file(`Sending WATCHLIST-COMPARE against ${lastChanged}`);
   commonMessaging.sendToMessagingService(msMessage);
 }
 
@@ -50,6 +52,7 @@ function markMissingFilesAsUnknown(remoteWatchlist) {
 
 function refresh(watchlist, lastChanged) {
   const filePaths = Object.keys(watchlist);
+  logger.file(`Received WATCHLIST-RESULT for ${lastChanged} with count: ${filePaths.length}`);
 
   if (filePaths.length === 0) {
     return Promise.resolve();


### PR DESCRIPTION
If a folder watch is submitted against a folder that doesn't exist on
GCS, MS doesn't record it in the watchlist as the error is returned early.
But local-storage will record the folder in the file metadata.

This ensures that any missing folders (in metadata with no files) are resubmitted by local-storage so that a new GCS check is triggered.