### PR TITLE
Set stale when MS provides token

### DIFF
--- a/src/messaging/watch/watch.js
+++ b/src/messaging/watch/watch.js
@@ -10,9 +10,7 @@ function handleFileWatchResult(message) {
 
   logger.file(`Received version ${version} for ${filePath}`);
 
-  const status = token && db.fileMetadata.isVersionMismatch(filePath, version) ?
-    "STALE" :
-    "CURRENT";
+  const status = token ? "STALE" : "CURRENT";
 
   return update.updateWatchlistAndMetadata({filePath, version, status, token})
   .then(()=>{


### PR DESCRIPTION
The second check for current version mismatch doesn't work in cases
where a watch is submitted for a file and then another watch is
submitted before the first watch has resulted in a completed download.

The first will update the version, and then the second will set
CURRENT even though the download isn't yet complete.