### PR TITLE
Handle empty watchlist

### DIFF
--- a/src/messaging/watch/watchlist.js
+++ b/src/messaging/watch/watchlist.js
@@ -65,7 +65,7 @@ function refresh(watchlist, lastChanged) {
   const filePaths = Object.keys(watchlist);
   logger.file(`Received WATCHLIST-RESULT for ${lastChanged} with count: ${filePaths.length}`);
 
-  if (filePaths.length === 0) {
+  if (filePaths.length === 0 && lastChanged !== "0") {
     return Promise.resolve();
   }
 

--- a/test/unit/messaging/watch/watchlist.js
+++ b/test/unit/messaging/watch/watchlist.js
@@ -253,6 +253,29 @@ describe("watchlist - unit", () => {
       });
     });
 
+    it("rewatches local files and folders missing from remote watchlist when remote returns empty watchlist and version 0", () => {
+      const testEntries = [
+        {filePath: "bucket/file1", status: "CURRENT", version: "1"},
+        {filePath: "bucket/file2", status: "CURRENT", version: "2"},
+        {filePath: "bucket/file3", status: "CURRENT", version: "3"}
+      ];
+
+      simple.mock(db.fileMetadata, "get").callFn(filePath =>
+        testEntries.find(entry => entry.filePath === filePath)
+      );
+      simple.mock(db.watchlist, "allEntries").returnWith(testEntries);
+
+      const remoteWatchlist = {};
+
+      return watchlist.refresh(remoteWatchlist, "0")
+      .then(() => {
+        assert.equal(db.fileMetadata.put.called, true);
+
+        assert.equal(db.watchlist.setLastChanged.callCount, 1);
+        assert.equal(db.watchlist.setLastChanged.lastCall.args[0], 0);
+      });
+    });
+
     it("does not refresh anything if there is no remote watchlist provided", () => {
       const testEntries = [
         {filePath: "bucket/file1", status: "CURRENT", version: "1"},


### PR DESCRIPTION
## Description
Mark local files and folders when server watchlist is empty and last changed is 0

## Motivation and Context
This is to force refreshing local files when messaging service watchlist is empty when data is lost on the server causing issues such as https://github.com/Rise-Vision/rise-launcher-electron/issues/832

## How Has This Been Tested?
Tested locally using stage environment by deleting the watchlist and last changed manually from redis 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
