### PR TITLE
Don't unencode apostrophe

### DIFF
--- a/src/files/file.js
+++ b/src/files/file.js
@@ -14,14 +14,8 @@ const requestRetries = 4;
 
 const requestFile = (signedURL) => {
 
-  // As per https://github.com/request/request/issues/2390 we need to manually undo the ' escape
-  const uri = urlParse(signedURL);
-  uri.pathname = uri.pathname.replace(/%27/g, "'")
-  uri.path = uri.path.replace(/%27/g, "'")
-  uri.href = uri.href.replace(/%27/g, "'")
-
   const options = {
-    uri,
+    uri: urlParse(signedURL),
     timeout: config.secondMillis * twoMinTimeout,
     resolveWithFullResponse: true,
     proxy: proxy.getProxyUri()

--- a/test/unit/files/file.js
+++ b/test/unit/files/file.js
@@ -76,10 +76,10 @@ describe("File", ()=>{
         })
     });
 
-    it("should not escape ' character on signed url", ()=>{
+    it("should not unencode %27 (apostrophe character) on signed url", ()=>{
       const mock = simple.mock(request, "get");
 
-      const pathWithApostrophe = "/test-'file'.jpg";
+      const pathWithApostrophe = "/test-%27file%27jpg";
       const testSignedURLWithApostrophe = `http://test-signed-url.com${pathWithApostrophe}`;
 
       file.request(testFilePath, testSignedURLWithApostrophe, 4, 0);


### PR DESCRIPTION
Since the node js storage library [now](https://github.com/googleapis/nodejs-storage/pull/905) encodes apostrophe the url provider is returning signed URLs containing %27. If this module unencodes back to ' then the signed url is no longer correct.

## Description
This change stops local storage from mangling the signed url.

## Motivation and Context
Why is this change required? https://github.com/Rise-Vision/rise-vision-apps/issues/1621

## How Has This Been Tested?
Tested locally with older version of url provider and newer version. Confirmed issue is exactly as described. Older version returns ' while newer version returns %27. Will test in player once staged.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
